### PR TITLE
Update Java version

### DIFF
--- a/compose/opencga-tomcat/Dockerfile
+++ b/compose/opencga-tomcat/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:16.04
 MAINTAINER OpenCB
 
 # Take from: https://launchpad.net/~webupd8team/+archive/ubuntu/java
-ARG JAVA_VERSION="8u171-1~webupd8~0"
+ARG JAVA_VERSION="8u181-1~webupd8~1"
 
 # Install dependencies
 RUN apt-get update && \

--- a/compose/opencga/Dockerfile
+++ b/compose/opencga/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:16.04
 MAINTAINER OpenCB
 
 # Take from: https://launchpad.net/~webupd8team/+archive/ubuntu/java
-ARG JAVA_VERSION="8u171-1~webupd8~0"
+ARG JAVA_VERSION="8u181-1~webupd8~1"
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
A new oracle-java8-installer package was built due to a new upstream
release. The old package is unavailable, resulting in failed Docker
builds without this patch.