### PR TITLE
Fix write permissions for filebeat.yml

### DIFF
--- a/compose/opencga-filebeat/Dockerfile
+++ b/compose/opencga-filebeat/Dockerfile
@@ -4,4 +4,5 @@ FROM docker.elastic.co/beats/filebeat:6.3.0
 USER root
 
 COPY filebeat.yml /usr/share/filebeat/filebeat.yml
+RUN chmod go-w /usr/share/filebeat/filebeat.yml
 RUN chown root /usr/share/filebeat/filebeat.yml


### PR DESCRIPTION
Filebeat fails to start if write permissions are set for group or
other users.